### PR TITLE
feat: LocalStackにて開発環境を整える

### DIFF
--- a/localstack/.gitignore
+++ b/localstack/.gitignore
@@ -1,0 +1,1 @@
+docker_files/localstack/tmp/*

--- a/localstack/README.md
+++ b/localstack/README.md
@@ -1,0 +1,1 @@
+# LocalStackを使用して、AWS Lambdaの開発を行う

--- a/localstack/README.md
+++ b/localstack/README.md
@@ -1,1 +1,13 @@
 # LocalStackを使用して、AWS Lambdaの開発を行う
+
+## Ruby
+
+### Lambda関数の更新
+```sh
+sh ruby/update_lambda.sh
+```
+
+### 実行
+```sh
+docker-compose exec localstack awslocal lambda invoke --function-name localstack-lambda-ruby /tmp/docker_files/output.txt 
+```

--- a/localstack/compose.yml
+++ b/localstack/compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  localstack:
+    image: localstack/localstack:latest
+    ports:
+      - 4566:4566
+    environment:
+      DEBUG: 1
+      DOCKER_HOST: unix:///var/run/docker.sock
+      SERVICES: 's3'
+    volumes:
+      - ./docker_files/localstack/init/ready.d:/etc/localstack/init/ready.d
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/localstack/compose.yml
+++ b/localstack/compose.yml
@@ -1,6 +1,14 @@
 version: '3'
 
 services:
+  ruby:
+    build:
+      context: .
+      dockerfile: ./docker_files/Dockerfile.ruby
+    volumes:
+      - ./ruby:/app
+      - app_bundle:/usr/local/bundle
+
   localstack:
     image: localstack/localstack:latest
     ports:
@@ -12,3 +20,7 @@ services:
     volumes:
       - ./docker_files/localstack/init/ready.d:/etc/localstack/init/ready.d
       - /var/run/docker.sock:/var/run/docker.sock
+
+volumes:
+  app_bundle:
+    external: false

--- a/localstack/compose.yml
+++ b/localstack/compose.yml
@@ -19,6 +19,7 @@ services:
       SERVICES: 's3'
     volumes:
       - ./docker_files/localstack/init/ready.d:/etc/localstack/init/ready.d
+      - ./docker_files/localstack/tmp:/tmp/docker_files
       - /var/run/docker.sock:/var/run/docker.sock
 
 volumes:

--- a/localstack/docker_files/Dockerfile.ruby
+++ b/localstack/docker_files/Dockerfile.ruby
@@ -1,0 +1,10 @@
+FROM ruby:3.2.2
+
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev vim
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY ruby/Gemfile /app/Gemfile
+COPY ruby/Gemfile.lock /app/Gemfile.lock
+RUN bundle install

--- a/localstack/docker_files/localstack/init/ready.d/setup.sh
+++ b/localstack/docker_files/localstack/init/ready.d/setup.sh
@@ -2,4 +2,11 @@
 
 awslocal s3 mb s3://sample.bucket
 touch example.txt
-awslocal s3 cp sample.txt s3://sample.bucket/sample
+awslocal s3 cp example.txt s3://sample.bucket/sample
+
+awslocal lambda create-function \
+    --function-name localstack-lambda-ruby \
+    --runtime ruby3.2 \
+    --zip-file fileb:///tmp/docker_files/ruby_initializa.zip \
+    --handler lambda_function.lambda_handler \
+    --role arn:aws:iam::000000000000:role/lambda-role

--- a/localstack/docker_files/localstack/init/ready.d/setup.sh
+++ b/localstack/docker_files/localstack/init/ready.d/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+awslocal s3 mb s3://sample.bucket

--- a/localstack/docker_files/localstack/init/ready.d/setup.sh
+++ b/localstack/docker_files/localstack/init/ready.d/setup.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
 awslocal s3 mb s3://sample.bucket
+touch example.txt
+awslocal s3 cp sample.txt s3://sample.bucket/sample

--- a/localstack/ruby/Gemfile
+++ b/localstack/ruby/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+ruby '3.2.2'
+
+gem 'nokogiri'
+gem 'aws-sdk-s3'

--- a/localstack/ruby/Gemfile.lock
+++ b/localstack/ruby/Gemfile.lock
@@ -1,0 +1,39 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    aws-eventstream (1.2.0)
+    aws-partitions (1.834.0)
+    aws-sdk-core (3.185.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.72.0)
+      aws-sdk-core (~> 3, >= 3.184.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.136.0)
+      aws-sdk-core (~> 3, >= 3.181.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.6)
+    aws-sigv4 (1.6.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+    jmespath (1.6.2)
+    nokogiri (1.15.4-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
+      racc (~> 1.4)
+    racc (1.7.1)
+
+PLATFORMS
+  aarch64-linux
+  x86_64-linux
+
+DEPENDENCIES
+  aws-sdk-s3
+  nokogiri
+
+RUBY VERSION
+   ruby 3.2.2p53
+
+BUNDLED WITH
+   2.4.10

--- a/localstack/ruby/lambda_function.rb
+++ b/localstack/ruby/lambda_function.rb
@@ -14,5 +14,3 @@ end
 def credentials
   Aws::Credentials.new('access_key_id', 'secret_access_key')
 end
-
-puts handler(event: {}, context: {})

--- a/localstack/ruby/lambda_function.rb
+++ b/localstack/ruby/lambda_function.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'aws-sdk-s3'
+
+def lambda_handler(event:, context:)
+  { results: JSON.generate(client.list_objects_v2({ bucket: 'sample.bucket', prefix: 'sample' }).contents) }
+end
+
+def client
+  @client ||= Aws::S3::Client.new({region: 'ap-northeast-1', credentials: credentials, endpoint: 'http://localstack:4566', force_path_style: true})
+end
+
+def credentials
+  Aws::Credentials.new('access_key_id', 'secret_access_key')
+end
+
+puts handler(event: {}, context: {})

--- a/localstack/ruby/update_lambda.sh
+++ b/localstack/ruby/update_lambda.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+zip_file=docker_files/localstack/tmp/lambda_function.zip
+docker_zip_file=/tmp/docker_files/lambda_function.zip
+zip -j ${zip_file} ruby/lambda_function.rb
+docker-compose exec localstack awslocal lambda update-function-code --function-name localstack-lambda-ruby --zip-file fileb://${docker_zip_file} --endpoint-url=http://localhost:4566
+rm ${zip_file}


### PR DESCRIPTION
## はまりどころ
### HookのShellが実行できない
```python
localstack-localstack-1  | 2023-10-07T02:43:35.297 ERROR --- [  MainThread] localstack.runtime.init    : Error while running script Script(path='/etc/localstack/init/ready.d/setup.sh', stage=READY, state=ERROR)
localstack-localstack-1  | Traceback (most recent call last):
localstack-localstack-1  |   File "/opt/code/localstack/localstack/runtime/init.py", line 136, in run_stage
localstack-localstack-1  |     runner.run(script.path)
localstack-localstack-1  |   File "/opt/code/localstack/localstack/runtime/init.py", line 69, in run
localstack-localstack-1  |     exit_code = subprocess.call(args=[], executable=path)
localstack-localstack-1  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
localstack-localstack-1  |   File "/usr/local/lib/python3.11/subprocess.py", line 389, in call
localstack-localstack-1  |     with Popen(*popenargs, **kwargs) as p:
localstack-localstack-1  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
localstack-localstack-1  |   File "/usr/local/lib/python3.11/subprocess.py", line 1026, in __init__
localstack-localstack-1  |     self._execute_child(args, executable, preexec_fn, close_fds,
localstack-localstack-1  |   File "/usr/local/lib/python3.11/subprocess.py", line 1950, in _execute_child
localstack-localstack-1  |     raise child_exception_type(errno_num, err_msg, err_filename)
localstack-localstack-1  | OSError: [Errno 8] Exec format error: '/etc/localstack/init/ready.d/setup.sh'
```
- https://docs.localstack.cloud/references/init-hooks/

#### 原因
- https://github.com/localstack/localstack/issues/8688